### PR TITLE
웹사이트 최신화 및 개선

### DIFF
--- a/src/components/FeaturedSpeakers.astro
+++ b/src/components/FeaturedSpeakers.astro
@@ -46,7 +46,7 @@ featuredSpeakers.push({
         {
             featuredSpeakers.map((speaker) => (
                 <Col size={4} medium={3}>
-                    <div class="p-media-object--large">
+                    <a class="p-media-object--large p-button--base" href={speaker.url} target="_blank">
                         <img
                             src={speaker.profileImg ? 
                                 `https://events.canonical.com/user/${speaker.profileImg}/picture-default`
@@ -58,17 +58,15 @@ featuredSpeakers.push({
                             loading="lazy"
                         />
                         <div class="p-media-object__details">
-                            <a href={speaker.url}>
-                                <h3>
-                                    {speaker.name}
-                                </h3>
-                            </a>
+                            <h3>
+                                {speaker.name}
+                            </h3>
                             <p class="p-media-object__content">
                                 {speaker.title}
                             </p>
                             <ul class="p-media-object__meta-list" />
                         </div>
-                    </div>
+                    </a>
                 </Col>
             ))
         }
@@ -82,3 +80,18 @@ featuredSpeakers.push({
     </Row>
 </Strip>
 }
+
+<style>
+    h3 {
+        color: var(--vf-color-link-default);
+    }
+
+    h3, .p-media-object__content {
+        margin-bottom: 0;
+    }
+
+    .p-button--base {
+        text-align: start;
+        justify-content: start;
+    }
+</style>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -84,4 +84,8 @@ const t = useTranslations(lang);
     <Sponsors/>
 </Shell>
 
-<style></style>
+<style>
+    button[disabled=""]{
+        opacity: .60;
+    }
+</style>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -39,7 +39,10 @@ const t = useTranslations(lang);
         <Row>
             <Col size={3} />
             <Col size={9}>
-                <a href={`/cfp`} class="p-button--positive">{t("home.cfp")}</a>
+                <!--
+                <a href={`/schedules`} class="p-button--positive">{t("nav.schedules")}</a>
+                -->
+                <Button appearance="positive" disabled>{t("nav.schedules")}</Button>
                 <a href={`/tickets`} class="p-button">{t("home.tickets")}</a>
                 <a href={`/${lang}/sponsors/become-a-sponsor/`} class="p-button"
                     >{t("home.sponsor")}</a

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -42,8 +42,7 @@ const t = useTranslations(lang);
                 <!--
                 <a href={`/schedules`} class="p-button--positive">{t("nav.schedules")}</a>
                 -->
-                <Button appearance="positive" disabled>{t("nav.schedules")}</Button>
-                <a href={`/tickets`} class="p-button">{t("home.tickets")}</a>
+                <a href={`/tickets`} class="p-button--positive" target="_blank">{t("home.tickets")}</a>
                 <a href={`/${lang}/sponsors/become-a-sponsor/`} class="p-button"
                     >{t("home.sponsor")}</a
                 >
@@ -84,8 +83,4 @@ const t = useTranslations(lang);
     <Sponsors/>
 </Shell>
 
-<style>
-    button[disabled=""]{
-        opacity: .60;
-    }
-</style>
+<style></style>

--- a/src/pages/en/venue-and-safety.mdx
+++ b/src/pages/en/venue-and-safety.mdx
@@ -43,13 +43,13 @@ import OpenStreetMap from "../../components/OpenStreetMap.astro";
 
 ### Hall
 
-> Some events, such as opening, closing, lightning talks, will be held in all halls by removing the partitions.
+> Some events, such as opening, closing, key signing party, lightning talks, will be held in all halls by removing the partitions.
 
 ![Hall](/venue/hall.png)
 
-- Hall A: Talks
-- Hall B: Workshops
-- Hall C: Talks & BoFs
+- Hall A: Workshops
+- Hall B: Talks & BoFs
+- Hall C: Talks
 
 You can charge your electronic devices using power strips inside the desks, and WiFi connection will be provided for staffs, speakers, and attendees who attends workshop session during the event.
 

--- a/src/pages/ko/venue-and-safety.mdx
+++ b/src/pages/ko/venue-and-safety.mdx
@@ -42,13 +42,13 @@ import OpenStreetMap from "../../components/OpenStreetMap.astro";
 
 ### Hall
 
-> 개회, 폐회, 라이트닝 토크 등 일부 행사는 홀 사이의 칸막이를 제거하여 전체 홀 통합으로 진행됩니다.
+> 개회, 폐회, 키 사이닝 파티, 라이트닝 토크 등 일부 행사는 홀 사이의 칸막이를 제거하여 전체 홀 통합으로 진행됩니다.
 
 ![홀 전경](/venue/hall.png)
 
-- Hall A: 강연
-- Hall B: 워크샵
-- Hall C: 강연 및 BoF
+- Hall A: 워크샵
+- Hall B: 강연 및 BoF
+- Hall C: 강연
 
 책상에 비치된 멀티탭을 이용하여 전자기기의 충전이 가능하며, WiFi는 행사 당일 워크숍 등 WiFi가 필수적으로 필요한 세션과 행사 관계자에 한해서만 제공합니다.
 


### PR DESCRIPTION
이번 PR 변경 사항은 다음과 같습니다.

### 시간표 페이지로 이동 위한 버튼 추가

![image](https://github.com/ubuntu-kr/2024.ubuntu-kr.org/assets/7126454/a00ee7e9-6fbe-463f-8bcf-404b8e4a94b3)

현재 비공개 상태이므로 비활성화 요청이 있어 임시로 버튼만 추가하고, 비활성화 처리 및 밝기 조정하였습니다.

### 문서 최신화

- 장소 페이지에서 홀 구성이 작업 중인 현행 시간표와 반대로 안내되어 있어 이를 바로잡았습니다.

### 주요 연사 링크 관련 개선

![image](https://github.com/ubuntu-kr/2024.ubuntu-kr.org/assets/7126454/6f636939-3ce5-438f-9be8-6e9e2064890a)

- 연사자 이름을 눌러야만 세션 정보로 이동했던 현행 웹사이트에서 프로필 사진, 세션 이름 등 다른 항목을 눌러도 이동할 수 있도록 조정하였습니다.