### PR TITLE
개인 후원 및 회비 회원 페이지 추가

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,10 @@ export const config = {
                     {
                         label: t('nav.sponsors.list'),
                         url: `/${locale}/sponsors/our-sponsors`
+                    },
+                    {
+                        label: t('nav.patrons'),
+                        url: `/${locale}/patrons`
                     }
                 ]
             }

--- a/src/data/patrons.ts
+++ b/src/data/patrons.ts
@@ -1,0 +1,25 @@
+export const patrons = [
+    {
+        name: "강성진",
+        org: null
+    },
+    {
+        name: "윤성수",
+        org: "시토리"
+    },
+    {
+        name: "한영빈",
+        org: "우분투한국커뮤니티"
+    }
+]
+
+export const ukc = [
+    {
+        name: "한영빈",
+        org: "우분투한국커뮤니티"
+    },
+    {
+        name: "김세영",
+        org: "Canonical Ltd."
+    }
+]

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -37,6 +37,7 @@ export const languages = {
       'nav.sponsors': 'Sponsors/Patrons',
       'nav.sponsors.join': 'Become a sponsor',
       'nav.sponsors.list': 'Our sponsors',
+      'nav.patrons': 'Individual patrons and Members with dues',
       'sponsor.about': 'About the sponsor',
       'sponsor.website': 'Visit website',
     },
@@ -71,6 +72,7 @@ export const languages = {
       'nav.sponsors': '후원사/개인후원',
       'nav.sponsors.join': '후원사 등록 안내',
       'nav.sponsors.list': '참여 후원사',
+      'nav.patrons': '개인 후원자 및 회비 회원',
       'sponsor.about': '후원사 소개',
       'sponsor.website': '웹사이트 방문'
     },

--- a/src/pages/en/patrons.mdx
+++ b/src/pages/en/patrons.mdx
@@ -1,0 +1,43 @@
+---
+layout: /src/layouts/MarkdownLayout.astro
+title: Individual Patrons and Members with dues
+---
+import { patrons, ukc } from "@data/patrons";
+import { Col, Row, Card } from "@canonical/react-components"
+
+
+## Individual patrons
+
+People listed below are Individual patrons of UbuCon Korea 2024.
+
+We got total {patrons.length} individual patron{patrons.length > 1 ? "s":""} this year!
+
+Thanks to every patrons for supporting our event!
+
+> **Note** Only patrons who agreed to display their names are displayed here.
+
+<Row>
+    {patrons.map((person) => (
+        <Col size={3}>
+            <Card title={person.name}>{person.org ?? "-"}</Card>
+        </Col>
+    ))}
+</Row>
+
+## Ubuntu Korea Community Members with dues
+
+People listed below are Ubuntu Korea Community Members with dues who bought tickets to participate in UbuCon Korea 2024. 
+
+We got total {ukc.length} participant{ukc.length > 1 ? "s":""} this year!
+
+Thanks to every members for supporting our event!
+
+> **Note** Only members who agreed to display their names are displayed here.
+
+<Row>
+    {ukc.map((person) => (
+        <Col size={3}>
+            <Card title={person.name}>{person.org ?? "-"}</Card>
+        </Col>
+    ))}
+</Row>

--- a/src/pages/ko/patrons.mdx
+++ b/src/pages/ko/patrons.mdx
@@ -1,0 +1,41 @@
+---
+layout: /src/layouts/MarkdownLayout.astro
+title: 개인 후원자 및 회비 회원
+---
+import { patrons, ukc } from "@data/patrons";
+import { Col, Row, Card } from "@canonical/react-components"
+
+
+## 개인 후원자
+
+금번 우부콘 코리아 2024에서는 총 {patrons.length}명의 참가자{patrons.length > 1 ? " 분들":""}께서 후원해주셨습니다!
+
+후원해주신 모든 후원자 분들께 감사드립니다!
+
+> 개인 후원자 정보 공개에 동의한 분들의 성함 및 소속만이 여기 등재됩니다.
+
+<Row>
+    {patrons.map((person) => (
+        <Col size={3}>
+            <Card title={person.name}>{person.org ?? "-"}</Card>
+        </Col>
+    ))}
+</Row>
+
+## 회비 회원
+
+아래는 본 행사를 개최하는 우분투한국커뮤니티의 회비 회원 중 행사에 참여하신 분들의 목록입니다.
+
+올해 총 {ukc.length}명의 참가자{ukc.length > 1 ? " 분들":""}께서 참여해주셨습니다!
+
+참여해주신 모든 회비 회원님께 감사드립니다.
+
+> 행사에 참여한 우분투한국커뮤니티의 회비 회원 중 정보 공개에 동의하신 분들의 성함 및 소속만이 여기 등재됩니다.
+
+<Row>
+    {ukc.map((person) => (
+        <Col size={3}>
+            <Card title={person.name}>{person.org ?? "-"}</Card>
+        </Col>
+    ))}
+</Row>


### PR DESCRIPTION
개인 후원 및 회비 회원 페이지를 추가하는 PR입니다.

후원사 관련 최신 정보 반영은 추후 후원사 답변 등 고려하여 향후 추가 작업토록 하겠습니다.